### PR TITLE
feat: fire user events

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ use({ "NStefan002/screenkey.nvim", tag = "*" })
 | `clear_after`         | clear the input after `<clear_after>` seconds of inactivity                                                                                                                                                                                                                                                                                         |
 | `disable`             | temporarily disable screenkey (for example when inside of the terminal)                                                                                                                                                                                                                                                                             |
 | `disable.filetypes`   | for example: `toggleterm` or `toml`                                                                                                                                                                                                                                                                                                                 |
+| `disable.events`      | disable `User` events                                                                                                                                                                                                                                                                                                                               |
 | `disable.buftypes`    | see `:h 'buftype'`, for example: `terminal`                                                                                                                                                                                                                                                                                                         |
 | `group_mappings`      | for example: `<leader>sf` opens up a fuzzy finder, if the `group_mappings` option is set to `true`, every time you open up a fuzzy finder with `<leader>sf`, Screenkey will show `␣sf` instead of `␣ s f` to indicate that the used key combination was a defined mapping.                                                                          |
 | `show_leader`         | if this option is set to `true`, in the last example instead of `␣ s f` Screenkey will display `<leader> s f` (of course, if the `<space>` is `<leader>`), if the current key is not a defined mapping, Screenkey will display `<space>` as `␣`                                                                                                     |
@@ -168,6 +169,23 @@ or
 > [!NOTE]
 > If you're using a terminal inside of the Neovim, and you want screenkey to automatically stop displaying your keys when you're
 > inside of the terminal, see `disable` option in the plugin configuration.
+
+-   For fully custom statusline users, screenkey will fire `User` events if `vim.g.screenkey_statusline_component` is enabled. There are two patterns: `ScreenkeyUpdated` on keypress and `ScreenkeyCleared` when clearing screenkey after inactivity (see `clear_after` option). If you are experiencing performance issues and do not rely on these events, you can disable them with the `disable.events` option. Example usage with [heirline](https://github.com/rebelot/heirline.nvim):
+
+```lua
+require("heirline").setup({
+    statusline = {
+        {
+            provider = function() return require("screenkey").get_keys() end,
+            update = {
+                "User",
+                pattern = "Screenkey*",
+                callback = vim.schedule_wrap(function() vim.cmd("redrawstatus") end),
+            },
+        },
+    },
+})
+```
 
 ## 🙏 I took inspiration (and some code) from
 

--- a/lua/screenkey/config.lua
+++ b/lua/screenkey/config.lua
@@ -16,6 +16,7 @@ M.defaults = {
     disable = {
         filetypes = {},
         buftypes = {},
+        events = false,
     },
     show_leader = true,
     group_mappings = false,
@@ -102,6 +103,7 @@ function M.validate_config(config)
         ok, err = Util.validate({
             filetypes = { config.disable.filetypes, "table", true },
             buftypes = { config.disable.buftypes, "table", true },
+            events = { config.disable.events, "boolean", true },
         }, config.disable, "screenkey.config.disable")
         if not ok then
             table.insert(errors, err)

--- a/lua/screenkey/config_types.lua
+++ b/lua/screenkey/config_types.lua
@@ -5,8 +5,8 @@
 ---@field compress_after? integer
 --- clear the input after `<clear_after>` seconds of inactivity
 ---@field clear_after? number
---- disable screenkey for certain filetypes and/or buftypes
----@field disable? table<"filetypes" | "buftypes", string[]>
+--- disable screenkey events or for certain filetypes and/or buftypes
+---@field disable? { filetypes: string[], buftypes: string[], events: boolean }
 --- show '<leader>' in mappings
 ---@field show_leader? boolean
 --- display mappings in groups
@@ -29,8 +29,8 @@
 ---@field compress_after integer
 --- clear the input after `<clear_after>` seconds of inactivity
 ---@field clear_after number
---- disable screenkey for certain filetypes and/or buftypes
----@field disable table<"filetypes" | "buftypes", string[]>
+--- disable screenkey events or for certain filetypes and/or buftypes
+---@field disable { filetypes: string[], buftypes: string[], events: boolean }
 --- show '<leader>' in mappings
 ---@field show_leader boolean
 --- display mappings in groups

--- a/lua/screenkey/init.lua
+++ b/lua/screenkey/init.lua
@@ -68,6 +68,9 @@ local function create_timer()
                 if active then
                     clear_screenkey_buffer()
                 end
+                if not Config.options.disable.events and vim.g.screenkey_statusline_component then
+                    vim.api.nvim_exec_autocmds("User", { pattern = "ScreenkeyCleared" })
+                end
             end
         end)
     )
@@ -266,7 +269,8 @@ local function create_autocmds()
 end
 
 vim.on_key(function(key, typed)
-    if not active and not vim.g.screenkey_statusline_component then
+    local statusline_enabled = vim.g.screenkey_statusline_component
+    if not active and not statusline_enabled then
         kill_timer()
         return
     end
@@ -287,6 +291,9 @@ vim.on_key(function(key, typed)
     end
     if active then
         display_text()
+    end
+    if not Config.options.disable.events and statusline_enabled then
+        vim.api.nvim_exec_autocmds("User", { pattern = "ScreenkeyUpdated" })
     end
 end, ns_id)
 


### PR DESCRIPTION
Fixes #26.

---

As discussed in #26, this PR adds `User` event autocommands on keypresses and on clear. 

New configuration option:

- `disable.events`: boolean to opt-out of user events in case performance is impacted (default: `false`)

There is two separate patterns: `ScreenkeyUpdated` for keypresses and `ScreenkeyCleared` on clear. Both patterns are fired only when `vim.g.screenkey_statusline_component` is enabled and `disable.events` is `false`.

Note that I had to change the `disable` field annotation to be a table literal since the type of `events` is different than `filetypes` and `buftypes`.