### PR TITLE
fix: screenkey + `getcharstr` inside of expression mappings (#36)

### DIFF
--- a/lua/screenkey/init.lua
+++ b/lua/screenkey/init.lua
@@ -216,7 +216,15 @@ local function display_text()
     local padding =
         string.rep(" ", math.floor((Config.options.win_opts.width - api.nvim_strwidth(text)) / 2))
     local line = math.floor(Config.options.win_opts.height / 2)
-    api.nvim_buf_set_lines(bufnr, line, line + 1, false, { string.format("%s%s", padding, text) })
+    vim.schedule(function()
+        api.nvim_buf_set_lines(
+            bufnr,
+            line,
+            line + 1,
+            false,
+            { string.format("%s%s", padding, text) }
+        )
+    end)
 end
 
 local function create_autocmds()


### PR DESCRIPTION
- There is a list of things that are not allowed to do inside expression mappings (see `:h :map-expression`).
- `getcharstr()` "blocks" the editor in the expression mapping state while allowing other scheduled functions to be executed. If those scheduled functions do something that is not allowed inside expression mapping, there is an error.
- Error inside `on_key()` callback clears said callback (i.e. it stop being executed).