### PR TITLE
feat: expose active state

### DIFF
--- a/lua/screenkey/init.lua
+++ b/lua/screenkey/init.lua
@@ -347,4 +347,9 @@ function M.get_keys()
     return vim.g.screenkey_statusline_component and compress_output() or ""
 end
 
+---@return boolean
+function M.is_active()
+    return active
+end
+
 return M


### PR DESCRIPTION
Hey, thank you for this great plugin.

# Problem 
I needed the ability to hide some stuff on my screen in case screenkey is active.

# Solution
I exposed the active variable via a getter

# Example
```lua
		local notify = require("notify")
		local toggleScreenKey = function()
			vim.cmd("Screenkey toggle")
			-- change notification position
			notify.setup({
				top_down = screenkey.is_active(),
			})
		end

		vim.keymap.set("n", "<leader>tk", toggleScreenKey, { desc = "[T]oggle [S]creen[K]ey" })

```