### PR TITLE
feat: custom highlights that update with colorscheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ require("screenkey").setup({
         ["SUPER"] = "󰘳",
         ["<leader>"] = "<leader>",
     },
+    highlights = {
+        Float = { inherit = "NormalFloat" },
+        FloatBorder = { inherit = "FloatBorder" },
+        ScreenKey = { bg = { from = "NormalFloat" }, fg = { from = "Comment" } },
+    },
 })
 ```
 

--- a/doc/screenkey.nvim.txt
+++ b/doc/screenkey.nvim.txt
@@ -127,6 +127,11 @@ CONFIGURATION                    *screenkey.nvim-screenkey.nvim-configuration*
             ["SUPER"] = "󰘳",
             ["<leader>"] = "<leader>",
         },
+        highlights = {
+	    Float = { inherit = "NormalFloat" },
+	    FloatBorder = { inherit = "FloatBorder" },
+	    ScreenKey = { bg = { from = "NormalFloat" }, fg = { from = "Comment" } },
+        },
     })
 <
 

--- a/lua/screenkey/highlight.lua
+++ b/lua/screenkey/highlight.lua
@@ -1,0 +1,64 @@
+local api = vim.api
+local fmt = string.format
+
+local M = {}
+
+local attrs = {
+    fg = true,
+    bg = true,
+    sp = true,
+    blend = true,
+    bold = true,
+    italic = true,
+    standout = true,
+    underline = true,
+    undercurl = true,
+    underdouble = true,
+    underdotted = true,
+    underdashed = true,
+    strikethrough = true,
+    reverse = true,
+    nocombine = true,
+    link = true,
+    default = true,
+}
+
+local function get_hl_as_hex(opts, ns)
+    ns, opts = ns or 0, opts or {}
+    opts.link = opts.link ~= nil and opts.link or false
+    local hl = api.nvim_get_hl(ns, opts)
+    hl.fg = hl.fg and ("#%06x"):format(hl.fg)
+    hl.bg = hl.bg and ("#%06x"):format(hl.bg)
+    return hl
+end
+
+local function resolve_from_attribute(hl, attr)
+    if type(hl) ~= "table" then
+        return hl
+    end
+    if hl.from then
+        return get_hl_as_hex({ name = hl.from })[attr] or "NONE"
+    end
+    return hl[attr] or "NONE"
+end
+
+function M.set(ns, name, opts)
+    vim.validate({ opts = { opts, "table" }, name = { name, "string" }, ns = { ns, "number" } })
+    local hl = opts.clear and {} or get_hl_as_hex({ name = opts.inherit or name })
+    for attribute, hl_data in pairs(opts) do
+        if attrs[attribute] then
+            hl[attribute] = resolve_from_attribute(hl_data, attribute)
+        end
+    end
+    local ok, err = pcall(api.nvim_set_hl, ns, name, hl)
+    if not ok then
+        local msg = fmt("Failed to set highlight %s: %s", name, err)
+        require("screenkey.logger"):log(msg)
+        vim.notify(msg, vim.log.levels.ERROR)
+    end
+end
+
+return M
+
+-- Adapted from
+-- https://github.com/akinsho/dotfiles/blob/6f071329ab6e7846f44f105cdb1e67679fdd58c1/.config/nvim/lua/as/highlights.lua

--- a/lua/screenkey/types.lua
+++ b/lua/screenkey/types.lua
@@ -23,6 +23,8 @@
 ---@field filter? fun(keys: screenkey.queued_key[]): screenkey.queued_key[]
 --- how to display the special keys
 ---@field keys? table<string, string>
+--- custom highlight groups for the floating window and text
+---@field highlights? { Float: screenkey.highlight, FloatBorder: screenkey.highlight, ScreenKey: screenkey.highlight }
 
 ---@class screenkey.config.full : screenkey.config
 --- see ':h nvim_open_win()'
@@ -49,7 +51,30 @@
 ---@field filter fun(keys: screenkey.queued_key[]): screenkey.queued_key[]
 --- how to display the special keys
 ---@field keys table<string, string>
+--- custom highlight groups for the floating window and text
+---@field highlights { Float: screenkey.highlight, FloatBorder: screenkey.highlight, ScreenKey: screenkey.highlight }
 
 ---@class screenkey.queued_key
 ---@field key string
 ---@field is_mapping boolean
+
+---@class screenkey.highlight
+---@field fg? string|{ from: string }        Color for foreground (e.g., "#ff0000") or reference to another highlight group
+---@field bg? string|{ from: string }        Color for background (e.g., "#000000") or reference to another highlight group
+---@field sp? string|{ from: string }        Color for special (e.g., underline) or reference to another highlight group
+---@field blend? number                      Blend level (0-100)
+---@field bold? boolean
+---@field italic? boolean
+---@field standout? boolean
+---@field underline? boolean
+---@field undercurl? boolean
+---@field underdouble? boolean
+---@field underdotted? boolean
+---@field underdashed? boolean
+---@field strikethrough? boolean
+---@field reverse? boolean
+---@field nocombine? boolean
+---@field link? string                       Link to another highlight group
+---@field default? boolean                   Set as default
+---@field inherit? string                    Inherit from another highlight group
+---@field from? string                       Copy attributes from another highlight group

--- a/lua/screenkey/util.lua
+++ b/lua/screenkey/util.lua
@@ -59,6 +59,7 @@ end
 function M.is_mapping(key)
     local mode = api.nvim_get_mode()
     local mappings = api.nvim_get_keymap(mode.mode)
+    vim.list_extend(mappings, api.nvim_buf_get_keymap(0, mode.mode))
     for _, mapping in ipairs(mappings) do
         ---@diagnostic disable-next-line: undefined-field
         if key == mapping.lhs or key == vim.fn.keytrans(mapping.lhs) then


### PR DESCRIPTION

# Add custom highlight group for screenkey text #54 

The changes include:
- Added `highlight` to the configuration options
- Re-fetch highlights when colorscheme changes

This allows users to customize the appearance of displayed keystrokes separately from window styling, making the plugin more customizable.

Example usage:
```lua
require("screenkey").setup({
  highlights = {
    -- Normal floating window background
    Float = { inherit = "NormalFloat" },
    -- Border styling
    FloatBorder = { inherit = "FloatBorder" },
    -- Custom styling for the actual keystrokes text
    ScreenKey = { 
      bg = "#000000",  -- Black background
      fg = "#00ff00",  -- Bright green text for keypresses
      bold = true,     -- Make keypresses appear bold
    },
  },
})
```