### PR TITLE
Fix: Add '%' to screenkey.config.keys to help with lualine Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ require("screenkey").setup({
         ["ALT"] = "Alt",
         ["SUPER"] = "󰘳",
         ["<leader>"] = "<leader>",
+        ["%"] = "%%",
+
     },
 })
 ```

--- a/lua/screenkey/config.lua
+++ b/lua/screenkey/config.lua
@@ -72,6 +72,7 @@ M.defaults = {
         ["ALT"] = "Alt",
         ["SUPER"] = "󰘳",
         ["<leader>"] = "<leader>",
+        ["%"] = "%%",
     },
     notify_method = "echo",
     log = {


### PR DESCRIPTION
This PR fixes the open issue `#59: '%' symbol is not in screenkey.config.keys` by adding the line  `["%"] = "%%",` to  `lua/screenkey/config.lua`. Now pressing the `%` while the screenkey element on the lualine is active won't crash lualine by sending a single % symbol.