### PR TITLE
refactor: consistently use `str:<fun>` instead of `string.<fun>(str)`

### DIFF
--- a/lua/screenkey/health.lua
+++ b/lua/screenkey/health.lua
@@ -7,7 +7,7 @@ function M.check()
     if ok then
         vim.health.ok("Setup is correct")
     else
-        vim.health.error(string.format("Setup is incorrect:\n%s", err))
+        vim.health.error(("Setup is incorrect:\n%s"):format(err))
     end
 end
 

--- a/lua/screenkey/key_utils.lua
+++ b/lua/screenkey/key_utils.lua
@@ -83,19 +83,19 @@ function M.transform_input(in_key, group_mappings, show_leader)
                     end
                     if modifier == "C" then
                         table.insert(transformed_keys, {
-                            key = string.format("%s+%s", config.options.keys["CTRL"], key),
+                            key = ("%s+%s"):format(config.options.keys["CTRL"], key),
                             is_mapping = is_mapping,
                             consecutive_repeats = 1,
                         })
                     elseif modifier == "A" or modifier == "M" then
                         table.insert(transformed_keys, {
-                            key = string.format("%s+%s", config.options.keys["ALT"], key),
+                            key = ("%s+%s"):format(config.options.keys["ALT"], key),
                             is_mapping = is_mapping,
                             consecutive_repeats = 1,
                         })
                     elseif modifier == "D" then
                         table.insert(transformed_keys, {
-                            key = string.format("%s+%s", config.options.keys["SUPER"], key),
+                            key = ("%s+%s"):format(config.options.keys["SUPER"], key),
                             is_mapping = is_mapping,
                             consecutive_repeats = 1,
                         })

--- a/lua/screenkey/utils.lua
+++ b/lua/screenkey/utils.lua
@@ -25,13 +25,13 @@ end
 function M.validate(opts, user_config, path)
     local ok, err = pcall(vim.validate, opts)
     if not ok then
-        return false, string.format("- %s: %s", path, err)
+        return false, ("- %s: %s"):format(path, err)
     end
 
     local errors = {}
     for key, _ in pairs(user_config) do
         if not opts[key] then
-            table.insert(errors, string.format("- '%s' is not a valid key of %s", key, path))
+            table.insert(errors, ("- '%s' is not a valid key of %s"):format(key, path))
         end
     end
 
@@ -48,7 +48,7 @@ end
 function M.validate_keytable(opts, user_config, path)
     local ok, err = pcall(vim.validate, opts)
     if not ok then
-        return false, string.format("- %s: %s", path, err)
+        return false, ("- %s: %s"):format(path, err)
     end
 
     local errors = {}
@@ -56,12 +56,7 @@ function M.validate_keytable(opts, user_config, path)
         if (type(key) ~= "string" or type(value) ~= "string") and opts[key] == nil then
             table.insert(
                 errors,
-                string.format(
-                    "- both key and value ([%s] = %s) must be strings in %s",
-                    key,
-                    value,
-                    path
-                )
+                ("- both key and value ([%s] = %s) must be strings in %s"):format(key, value, path)
             )
         end
     end
@@ -77,7 +72,7 @@ end
 function M.split(str, sep)
     sep = sep or "%s"
     local t = {}
-    for s in string.gmatch(str, "([^" .. sep .. "]+)") do
+    for s in str:gmatch("([^" .. sep .. "]+)") do
         table.insert(t, s)
     end
     return t


### PR DESCRIPTION
## ✅ Checklist

- [X] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [X] PR title follows [the Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I have added/modified tests to cover my changes (if applicable)
- [ ] I have updated the documentation (if applicable)

## 📝 Description

I noticed a mix of `string` class operators which were not used consistently. I've enforced a single method:

```lua
-- BEFORE
string.format(str, ...)

-- AFTER
str:format(...)

-- OR
("%s"):format(...)
```

This does not affect the plugin in any way. This is merely for consistent code.
