### PR TITLE
chore(gitignore): ignore `doc/tags`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .luarc.json
+
+doc/tags


### PR DESCRIPTION
## ✅ Checklist

- [X] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [X] PR title follows [the Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I have added/modified tests to cover my changes (if applicable)
- [ ] I have updated the documentation (if applicable)

## 📝 Description

The auto-generated helptags are not ignored, which could cause issues with development and Version Control.
Therefore I took the liberty to ignore it, since it is not included in the repository.
